### PR TITLE
**[FIX]** Fix error with regex getting caught up on hls_audio strings

### DIFF
--- a/src/udemy_dl.py
+++ b/src/udemy_dl.py
@@ -248,13 +248,16 @@ def parse_video(json_source):
         for line in m3u8_str.splitlines():
             if not line.startswith('https://'):
                 continue
-            quality = re.match(r'.*/hls_(\d+)_', line).group(1)
-            dict_videos.setdefault(quality, line)
+            quality = re.match(r'.*/hls_(\d+)_', line)
+            if quality is None:
+                continue
+
+            dict_videos.setdefault(quality.group(1), line)
         found = True
 
     for item in quality_list:
         if dict_videos.get(item):
-            return (dict_videos[item], 'Video', caption_list)
+            return dict_videos[item], 'Video', caption_list
     logger.critical('Skipped. Expected quality not found!')
     return (None, None, None)
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide]().
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [X] I have used the project briefly.
- [ ] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

**If the project maintainer has any additional requirements, they will be listed here.**

- No additional requirements.

---

Fix the problem with the regex failing to find the hls quality because a url exists with hls_audio.

